### PR TITLE
Add Service Desk Organizations support

### DIFF
--- a/connector_jira/README.rst
+++ b/connector_jira/README.rst
@@ -82,6 +82,9 @@ You can now click on the button "Configuration Done".
 Syncronizations
 ^^^^^^^^^^^^^^^
 
+The tasks and worklogs are always imported from JIRA to Odoo, there
+is no synchronization in the other direction.
+
 Initial synchronizations
 """"""""""""""""""""""""
 
@@ -91,16 +94,41 @@ users" and "Import issue types". The users will be matched either by login or by
 Create and export a project
 """""""""""""""""""""""""""
 
-Projects are created in Odoo and exported to Jira. You can then create a
-project, set a Jira key.
-Then, open the Connectors tab, add a new link.
-You can chose the Jira to export to, and the type of project.
-You have to select the synchronized issue types, but the field is not editable
-until the record is saved. You need to save and edit it again to be able to
-select them.
+Projects can be created in Odoo and exported to Jira. You can then create a
+project, and use the action "Link with JIRA" and use the "Export to JIRA" action.
 
-TODO: add a quick button to push to JIRA via default backend.
+When you choose to export a project to JIRA, if you change the name
+or the key of the project, the new values will be pushed to JIRA.
 
+Link a project with JIRA
+""""""""""""""""""""""""
+
+If you already have a project on JIRA or prefer to create it first on JIRA,
+you can link an Odoo project. Use the "Link with JIRA" action on the project
+and select the "Link with JIRA" action.
+
+This action establish the link, then changes of the name or the key on either
+side are not pushed.
+
+Issue Types on Projects
+"""""""""""""""""""""""
+
+When you link a project, you have to select which issue types are synchronized.
+Only tasks of the selected types will be created in Odoo.
+
+If a JIRA worklog is added to a type of issue that is not synchronized,
+will attach to the closest task following these rules:
+
+* if a subtask, find the parent task
+* if no parent task, find the epic task (only if it is on the same project)
+* if no epic, attach to the project without being linked to a task
+
+Change synchronization configuration on a project
+"""""""""""""""""""""""""""""""""""""""""""""""""
+
+If you want to change the configuration of a project, such as which
+issue types are synchronized, you can open the "Connector" tab in
+the project settings and edit the "binding" with the backend.
 
 Synchronize tasks and worklogs
 """"""""""""""""""""""""""""""
@@ -114,7 +142,6 @@ imports. It is important to select the issue types so don't miss this step (need
 Known Issues
 ------------
 
-* The Project Jira binding must be saved first then edited again to add the issue types afterwards...
 * If an odoo user has no linked employee, worklogs will still be imported but
   with an empty employee
 * The tasks and worklogs deleted on JIRA are deleted if

--- a/connector_jira/__manifest__.py
+++ b/connector_jira/__manifest__.py
@@ -25,7 +25,7 @@
          'cryptography',
       ],
  },
- 'website': 'https://www.camptocamp.com',
+ 'website': 'https://github.com/camptocamp/connector-jira',
  'data': [
      'views/jira_menus.xml',
      'wizards/jira_backend_auth_views.xml',

--- a/connector_jira/__manifest__.py
+++ b/connector_jira/__manifest__.py
@@ -29,6 +29,7 @@
  'data': [
      'views/jira_menus.xml',
      'wizards/jira_backend_auth_views.xml',
+     'views/project_link_jira_views.xml',
      'views/jira_backend_views.xml',
      'views/jira_backend_report_templates.xml',
      'views/project_project_views.xml',

--- a/connector_jira/components/backend_adapter.py
+++ b/connector_jira/components/backend_adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging

--- a/connector_jira/components/base.py
+++ b/connector_jira/components/base.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.component.core import AbstractComponent

--- a/connector_jira/components/binder.py
+++ b/connector_jira/components/binder.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_jira/components/exporter.py
+++ b/connector_jira/components/exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_jira/components/importer.py
+++ b/connector_jira/components/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 """

--- a/connector_jira/components/mapper.py
+++ b/connector_jira/components/mapper.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import pytz

--- a/connector_jira/controllers/main.py
+++ b/connector_jira/controllers/main.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 """

--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models

--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -22,6 +22,11 @@ class JiraAccountAnalyticLine(models.Model):
     # in case we'll need it for an eventual export
     jira_issue_id = fields.Char()
 
+    _sql_constraints = [
+        ('jira_binding_backend_uniq', 'unique(backend_id, odoo_id)',
+         "A binding already exists for this line and this backend."),
+    ]
+
     @job(default_channel='root.connector_jira.import')
     @api.model
     def import_record(self, backend, issue_id, worklog_id, force=False):

--- a/connector_jira/models/jira_backend/common.py
+++ b/connector_jira/models/jira_backend/common.py
@@ -1,5 +1,5 @@
 # Copyright: 2015 LasLabs, Inc.
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import binascii

--- a/connector_jira/models/jira_backend/common.py
+++ b/connector_jira/models/jira_backend/common.py
@@ -505,15 +505,18 @@ class JiraBackend(models.Model):
 
     @api.model
     def get_api_client(self):
+        self.ensure_one()
+        # tokens are only readable by connector managers
+        backend = self.sudo()
         oauth = {
-            'access_token': self.access_token,
-            'access_token_secret': self.access_secret,
-            'consumer_key': self.consumer_key,
-            'key_cert': self.private_key,
+            'access_token': backend.access_token,
+            'access_token_secret': backend.access_secret,
+            'consumer_key': backend.consumer_key,
+            'key_cert': backend.private_key,
         }
         options = {
-            'server': self.uri,
-            'verify': self.verify_ssl,
+            'server': backend.uri,
+            'verify': backend.verify_ssl,
         }
         return JIRA(options=options, oauth=oauth)
 

--- a/connector_jira/models/jira_binding/common.py
+++ b/connector_jira/models/jira_binding/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models

--- a/connector_jira/models/jira_issue_type/common.py
+++ b/connector_jira/models/jira_issue_type/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models

--- a/connector_jira/models/jira_issue_type/importer.py
+++ b/connector_jira/models/jira_issue_type/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.connector.components.mapper import mapping

--- a/connector_jira/models/project_project/__init__.py
+++ b/connector_jira/models/project_project/__init__.py
@@ -1,2 +1,3 @@
 from . import common
+from . import project_link_jira
 from . import exporter

--- a/connector_jira/models/project_project/common.py
+++ b/connector_jira/models/project_project/common.py
@@ -9,7 +9,7 @@ import tempfile
 from jira import JIRAError
 from jira.utils import json_loads
 
-from odoo import api, fields, models, exceptions, _
+from odoo import api, fields, models, exceptions, _, tools
 
 from odoo.addons.component.core import Component
 
@@ -22,7 +22,7 @@ class JiraProjectBaseFields(models.AbstractModel):
     Shared by the binding jira.project.project
     and the wizard to link/create a JIRA project
     """
-    _name = 'jira.project.base.fields'
+    _name = 'jira.project.base.mixin'
 
     sync_issue_type_ids = fields.Many2many(
         comodel_name='jira.issue.type',
@@ -63,7 +63,7 @@ class JiraProjectBaseFields(models.AbstractModel):
 
 class JiraProjectProject(models.Model):
     _name = 'jira.project.project'
-    _inherit = ['jira.binding', 'jira.project.base.fields']
+    _inherit = ['jira.binding', 'jira.project.base.mixin']
     _inherits = {'project.project': 'odoo_id'}
     _description = 'Jira Projects'
 
@@ -77,6 +77,42 @@ class JiraProjectProject(models.Model):
         ('jira_binding_backend_uniq', 'unique(backend_id, odoo_id)',
          "A binding already exists for this project and this backend."),
     ]
+
+    # Disable and implement the constraint jira_binding_uniq as python because
+    # we need to override the in connector_jira_service_desk and it would try
+    # to create it again at every update because of the base implementation
+    # in the binding's parent model.
+    @api.model_cr
+    def _add_sql_constraints(self):
+        # we replace the sql constraint by a python one
+        # to include the organizations
+        constraints = []
+        for (key, definition, msg) in self._sql_constraints:
+            if key == 'jira_binding_uniq':
+                conname = '%s_%s' % (self._table, key)
+                has_definition = tools.constraint_definition(
+                    self.env.cr, conname
+                )
+                if has_definition:
+                    tools.drop_constraint(self.env.cr, self._table, conname)
+            else:
+                constraints.append((key, definition, msg))
+        self._sql_constraints = constraints
+        super()._add_sql_constraints()
+
+    @api.constrains('backend_id', 'external_id')
+    def _constrains_jira_uniq(self):
+        for binding in self:
+            same_link_bindings = self.search([
+                ('id', '!=', self.id),
+                ('backend_id', '=', self.backend_id.id),
+                ('external_id', '=', self.external_id),
+            ])
+            if same_link_bindings:
+                raise exceptions.ValidationError(_(
+                    "The project %s is already linked with the same"
+                    " JIRA project."
+                ) % (same_link_bindings.display_name))
 
     @api.onchange('backend_id')
     def onchange_project_backend_id(self):
@@ -103,7 +139,6 @@ class JiraProjectProject(models.Model):
         record = super().create(values)
         record._ensure_jira_key()
         return record
-
 
     @api.multi
     def write(self, values):

--- a/connector_jira/models/project_project/common.py
+++ b/connector_jira/models/project_project/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import json

--- a/connector_jira/models/project_project/exporter.py
+++ b/connector_jira/models/project_project/exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.component.core import Component

--- a/connector_jira/models/project_project/exporter.py
+++ b/connector_jira/models/project_project/exporter.py
@@ -12,11 +12,13 @@ class JiraProjectProjectListener(Component):
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_create(self, record, fields=None):
-        record.with_delay(priority=10).export_record(fields=fields)
+        if record.sync_action == 'export':
+            record.with_delay(priority=10).export_record(fields=fields)
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
     def on_record_write(self, record, fields=None):
-        record.with_delay(priority=10).export_record(fields=fields)
+        if record.sync_action == 'export':
+            record.with_delay(priority=10).export_record(fields=fields)
 
 
 class ProjectProjectListener(Component):
@@ -39,7 +41,8 @@ class ProjectProjectListener(Component):
             # we never want to export that.
             return
         for binding in record.jira_bind_ids:
-            binding.with_delay(priority=10).export_record(fields=fields)
+            if binding.sync_action == 'export':
+                binding.with_delay(priority=10).export_record(fields=fields)
 
 
 class JiraProjectProjectExporter(Component):

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -1,0 +1,181 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import logging
+
+import jira
+
+from odoo import api, fields, models, exceptions, _
+
+_logger = logging.getLogger(__name__)
+
+
+class ProjectLinkJira(models.TransientModel):
+    _name = 'project.link.jira'
+    _inherit = 'jira.project.base.fields'
+    _description = 'Link Project with JIRA'
+
+    project_id = fields.Many2one(
+        comodel_name='project.project',
+        name="Project",
+        required=True,
+        default=lambda self: self._default_project_id(),
+    )
+    jira_key = fields.Char(
+        string='JIRA Key',
+        size=10,  # limit on JIRA
+        required=True,
+        default=lambda self: self._default_jira_key(),
+    )
+    backend_id = fields.Many2one(
+        comodel_name='jira.backend',
+        string='Jira Backend',
+        required=True,
+        ondelete='restrict',
+        default=lambda self: self._default_backend_id(),
+    )
+    state = fields.Selection(
+        selection='_selection_state',
+        default='start',
+        required=True,
+    )
+    jira_project_id = fields.Many2one(
+        comodel_name='jira.project.project',
+    )
+
+    @api.model
+    def _selection_state(self):
+        return [
+            ('start', 'Start'),
+            ('issue_types', 'Issue Types'),
+            ('export_config', 'Export Config.'),
+            ('final', 'Final'),
+        ]
+
+    @api.model
+    def _default_project_id(self):
+        return self.env.context.get('active_id')
+
+    @api.model
+    def _default_jira_key(self):
+        project_id = self._default_project_id()
+        if not project_id:
+            return
+        project = self.env['project.project'].browse(project_id)
+        if project.jira_key:
+            return project.jira_key
+        valid = self.env['jira.project.project']._jira_key_valid
+        if valid(project.name):
+            return project.name
+
+    @api.model
+    def _default_backend_id(self):
+        backends = self.env['jira.backend'].search([])
+        if len(backends) == 1:
+            return backends.id
+
+    @api.constrains('jira_key')
+    def check_jira_key(self):
+        for record in self:
+            valid = self.env['jira.project.project']._jira_key_valid
+            if not valid(record.jira_key):
+                raise exceptions.ValidationError(
+                    _('%s is not a valid JIRA Key') % record.jira_key
+                )
+
+    def add_all_issue_types(self):
+        issue_types = self.env['jira.issue.type'].search([
+            ('backend_id', '=', self.backend_id.id)
+        ])
+        self.sync_issue_type_ids = issue_types.ids
+
+    def open_next(self):
+        state_method = getattr(self, 'state_exit_%s' % (self.state))
+        state_method()
+        return self._reopen_self()
+
+    def _reopen_self(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+    def state_exit_start(self):
+        if self.sync_action == 'export':
+            self.add_all_issue_types()
+        elif self.sync_action == 'link':
+            if not self.jira_project_id:
+                self._link_binding()
+        self.state = 'issue_types'
+
+    def state_exit_issue_types(self):
+        if self.sync_action == 'export':
+            self.state = 'export_config'
+        elif self.sync_action == 'link':
+            self._copy_issue_types()
+            self.state = 'final'
+
+    def state_exit_export_config(self):
+        if not self.jira_project_id:
+            self._create_export_binding()
+        self.state = 'final'
+
+    def _prepare_export_binding_values(self):
+        values = {
+            'backend_id': self.backend_id.id,
+            'odoo_id': self.project_id.id,
+            'jira_key': self.jira_key,
+            'sync_action': 'export',
+            'sync_issue_type_ids': [(6, 0, self.sync_issue_type_ids.ids)],
+            'project_template': self.project_template,
+            'project_template_shared': self.project_template_shared,
+        }
+        return values
+
+    def _create_export_binding(self):
+        values = self._prepare_export_binding_values()
+        self.jira_project_id = self.env['jira.project.project'].create(values)
+
+    def _link_binding(self):
+        with self.backend_id.work_on('jira.project.project') as work:
+            adapter = work.component(usage='backend.adapter')
+            try:
+                jira_project = adapter.get(self.jira_key)
+            except jira.exceptions.JIRAError:
+                _logger.exception('Error when linking to project %s',
+                                  self.project_id.id)
+                raise exceptions.UserError(
+                    _('Could not link %s, check that this project'
+                      ' keys exists in JIRA.') % (self.jira_key)
+                )
+            self._link_with_jira_project(work, jira_project)
+
+    def _link_with_jira_project(self, work, jira_project):
+        values = self._prepare_link_binding_values(jira_project)
+        self.jira_project_id = self.env['jira.project.project'].create(
+            values
+        )
+        type_binder = work.component(usage='binder',
+                                     model_name='jira.issue.type')
+        issue_types = self.env['jira.issue.type'].browse()
+        for jira_issue_type in jira_project.issueTypes:
+            issue_types |= type_binder.to_internal(
+                jira_issue_type.id
+            )
+        self.sync_issue_type_ids = issue_types.ids
+
+    def _prepare_link_binding_values(self, jira_project):
+        values = {
+            'backend_id': self.backend_id.id,
+            'odoo_id': self.project_id.id,
+            'jira_key': self.jira_key,
+            'sync_action': self.sync_action,
+            'external_id': jira_project.id,
+        }
+        return values
+
+    def _copy_issue_types(self):
+        self.jira_project_id.sync_issue_type_ids = self.sync_issue_type_ids.ids

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 class ProjectLinkJira(models.TransientModel):
     _name = 'project.link.jira'
-    _inherit = 'jira.project.base.fields'
+    _inherit = 'jira.project.base.mixin'
     _description = 'Link Project with JIRA'
 
     project_id = fields.Many2one(

--- a/connector_jira/models/project_task/common.py
+++ b/connector_jira/models/project_task/common.py
@@ -39,6 +39,11 @@ class JiraProjectTask(models.Model):
              "of the synchronizations.",
     )
 
+    _sql_constraints = [
+        ('jira_binding_backend_uniq', 'unique(backend_id, odoo_id)',
+         "A binding already exists for this task and this backend."),
+    ]
+
     @api.multi
     def unlink(self):
         if any(self.mapped('external_id')):

--- a/connector_jira/models/project_task/common.py
+++ b/connector_jira/models/project_task/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models, exceptions, _

--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import _

--- a/connector_jira/models/res_users/common.py
+++ b/connector_jira/models/res_users/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import _, api, exceptions, fields, models

--- a/connector_jira/models/res_users/importer.py
+++ b/connector_jira/models/res_users/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.component.core import Component

--- a/connector_jira/views/project_link_jira_views.xml
+++ b/connector_jira/views/project_link_jira_views.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="project_link_jira_form" model="ir.ui.view">
+    <field name="name">project.link.jira.form</field>
+    <field name="model">project.link.jira</field>
+    <field name="arch" type="xml">
+      <form>
+        <field name="state" invisible="1"/>
+        <h1>
+          <field name="jira_key"
+                 attrs="{'readonly': [('state', '!=', 'start')]}"
+                 class="oe_inline"
+                 placeholder="JIRA Key"/>
+        </h1>
+        <group name="start" attrs="{'invisible': [('state', '!=', 'start')]}">
+          <group>
+            <field name="backend_id"/>
+            <field name="sync_action" widget="radio"/>
+          </group>
+        </group>
+        <group name="issue_types" attrs="{'invisible': [('state', '!=', 'issue_types')]}">
+          <field name="sync_issue_type_ids" widget="many2many_checkboxes"/>
+
+          <div colspan="2">
+            <p class="oe_grey oe_inline">
+              The checkboxes define which types of JIRA issues will be imported
+              into Odoo. For instance, if you check 'Story', only issues of type
+              Story will be imported. Several choices possible.
+            </p>
+
+            <p class="oe_grey oe_inline">
+              There is a direct implication on the Worklogs.
+              When a worklog is done on a JIRA Sub-Task and this type is not
+              sync'ed, the worklog will be attached to the parent Task of the
+              Sub-Task. If the Task is not sync'ed, it will be attached to the
+              Epic. Finally, if there is no Epic, the worklog will not be
+              attached to any task.
+            </p>
+          </div>
+        </group>
+        <group name="export_config" attrs="{'invisible': [('state', '!=', 'export_config')]}">
+          <group>
+            <field name="project_template"/>
+            <field name="project_template_shared"
+                   attrs="{'invisible': [('project_template', '!=', 'shared')],
+                          'required': [('project_template', '=', 'shared')]}"/>
+          </group>
+        </group>
+        <div name="final" attrs="{'invisible': [('state', '!=', 'final')]}">
+          <p attrs="{'invisible': [('sync_action', '!=', 'export')]}">The project will be created on JIRA in background.</p>
+          <p attrs="{'invisible': [('sync_action', '!=', 'link')]}">The project is now linked with JIRA.</p>
+        </div>
+        <footer>
+          <div attrs="{'invisible': [('state', '=', 'final')]}">
+            <button name="open_next" string="Next" type="object" class="btn-primary"/>
+            <button string="Cancel" class="btn btn-default" special="cancel" />
+          </div>
+          <div attrs="{'invisible': [('state', '!=', 'final')]}">
+            <button string="Close" class="btn btn-primary" special="cancel" />
+          </div>
+        </footer>
+      </form>
+    </field>
+  </record>
+
+  <act_window id="open_project_link_jira"
+              name="Link with JIRA"
+              res_model="project.link.jira"
+              src_model="project.project"
+              groups="project.group_project_manager"
+              view_mode="form" target="new" view_type="form" />
+</odoo>

--- a/connector_jira/views/project_project_views.xml
+++ b/connector_jira/views/project_project_views.xml
@@ -6,6 +6,7 @@
     <field name="model">project.project</field>
     <field name="inherit_id" ref="project.edit_project"/>
     <field name="arch" type="xml">
+
       <xpath expr="//notebook" position="inside">
         <page string="Connector" name="connector">
           <group string="Jira">
@@ -35,6 +36,7 @@
             attrs="{'readonly': [('external_id', '!=', False)],
                     'invisible': [('project_template', '!=', 'shared')],
                     'required': [('project_template', '=', 'shared')]}"/>
+          <field name="sync_action"/>
           <div colspan="2">
             <p class="oe_grey oe_inline">
               The checkboxes define which types of JIRA issues will be imported
@@ -59,15 +61,39 @@
     </field>
   </record>
 
+  <record id="project_project_view_form_simplified" model="ir.ui.view">
+    <field name="name">project.project.view.form.simplified.jira</field>
+    <field name="model">project.project</field>
+    <field name="inherit_id" ref="project.project_project_view_form_simplified"/>
+    <field name="arch" type="xml">
+      <button name="edit_dialog" position="after">
+        <button string="Create and Link with JIRA" name="create_and_link_jira" type="object" class="btn-primary"/>
+      </button>
+    </field>
+  </record>
+
   <record id="view_jira_project_project_tree" model="ir.ui.view">
     <field name="name">jira.project.project.tree</field>
     <field name="model">jira.project.project</field>
     <field name="arch" type="xml">
-      <tree string="Jira Project">
+      <tree string="Jira Project" create="0">
         <field name="backend_id"/>
         <field name="external_id"/>
         <field name="sync_issue_type_ids"/>
       </tree>
+    </field>
+  </record>
+
+  <record model="ir.ui.view" id="view_project_kanban_jira">
+    <field name="name">project.project.kanban.jira</field>
+    <field name="model">project.project</field>
+    <field name="inherit_id" ref="project.view_project_kanban"/>
+    <field name="arch" type="xml">
+      <xpath expr="//div[hasclass('o_kanban_manage_reports')]/div[last()]" position="after">
+        <div groups="project.group_project_manager">
+          <a name="%(connector_jira.open_project_link_jira)d" type="action">Link with JIRA</a>
+        </div>
+      </xpath>
     </field>
   </record>
 

--- a/connector_jira/wizards/jira_backend_auth.py
+++ b/connector_jira/wizards/jira_backend_auth.py
@@ -1,5 +1,5 @@
 # Copyright: 2015 LasLabs, Inc.
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import requests

--- a/connector_jira/wizards/jira_backend_auth_views.xml
+++ b/connector_jira/wizards/jira_backend_auth_views.xml
@@ -2,7 +2,7 @@
 <odoo>
 <!--
     Copyright (C) 2014-2015 LasLabs [https://laslabs.com]
-    Copyright 2016 Camptocamp SA
+    Copyright 2016-2019 Camptocamp SA
 -->
 
   <record id="view_jira_backend_auth_form" model="ir.ui.view">

--- a/connector_jira_servicedesk/README.rst
+++ b/connector_jira_servicedesk/README.rst
@@ -1,0 +1,47 @@
+JIRA Connector - Service Desk Extension
+=======================================
+
+Setup
+-----
+
+A new button is added on the JIRA backend, to import the organizations
+of JIRA. Before, be sure to use the button "Configure Organization Link"
+in the "Advanced Configuration" tab.
+
+
+Features
+^^^^^^^^
+
+Organizations
+-------------
+
+On Service Desk, you can share projects with Organizations.
+You may want to use different Odoo projects according to the
+organizations. This is what this extension allows.
+
+Example:
+
+* You have one Service Desk project named "Earth Project" with key EARTH
+* On JIRA SD You share this project with organizations Themis and Rhea
+* However on Odoo, you want to track the hours differently for Themis and Rhea
+
+Steps on Odoo:
+
+* Create a Themis project, use the "Link with JIRA" action with the key EARTH
+* When you hit Next, the organization(s) you want to link must be set
+* Repeat with another project for Rhea
+
+If the project binding for the synchronization already exists, you can still edit it in the settings of the project and change the organizations.
+
+When a task or worklog is imported, it will search for a project having
+exactly the same set of organizations than the one of the task. If no
+project with the same set is found and you have a project configured
+without organization, the task will be linked to it.
+
+This means that, on Odoo, you can have shared project altogether with dedicated
+ones, while you only have one project on JIRA.
+
+* Tasks with org "Themis" will be attached to this project
+* Tasks with org "Rhea" will be attached to this project
+* Tasks with orgs "Themis" and "Rhea" will be attached to another project "Themis and Rhea"
+* The rest of the tasks will be attached to a fourth project (configured without organizations)

--- a/connector_jira_servicedesk/__init__.py
+++ b/connector_jira_servicedesk/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/connector_jira_servicedesk/__manifest__.py
+++ b/connector_jira_servicedesk/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 {
-    'name': 'JIRA Connector ServiceDesk',
+    'name': 'JIRA Connector - Service Desk Extension',
     'version': '11.0.1.0.0',
     'author': 'Camptocamp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',
@@ -9,7 +9,7 @@
     'depends': [
         'connector_jira',
     ],
-    'website': 'https://www.camptocamp.com',
+    'website': 'https://github.com/camptocamp/connector-jira',
     'data': [
         'views/jira_backend_views.xml',
         'views/project_project_views.xml',

--- a/connector_jira_servicedesk/__manifest__.py
+++ b/connector_jira_servicedesk/__manifest__.py
@@ -1,0 +1,20 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    'name': 'JIRA Connector ServiceDesk',
+    'version': '11.0.1.0.0',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'category': 'Connector',
+    'depends': [
+        'connector_jira',
+    ],
+    'website': 'https://www.camptocamp.com',
+    'data': [
+        'views/jira_backend_views.xml',
+        'views/project_project_views.xml',
+        'views/project_link_jira_views.xml',
+        'security/ir.model.access.csv',
+    ],
+    'installable': True,
+}

--- a/connector_jira_servicedesk/models/__init__.py
+++ b/connector_jira_servicedesk/models/__init__.py
@@ -1,0 +1,5 @@
+from . import account_analytic_line
+from . import jira_backend
+from . import project_project
+from . import jira_organization
+from . import project_task

--- a/connector_jira_servicedesk/models/account_analytic_line/__init__.py
+++ b/connector_jira_servicedesk/models/account_analytic_line/__init__.py
@@ -1,0 +1,1 @@
+from . import importer

--- a/connector_jira_servicedesk/models/account_analytic_line/importer.py
+++ b/connector_jira_servicedesk/models/account_analytic_line/importer.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.addons.component.core import Component
+
+
+class AnalyticLineImporter(Component):
+    _inherit = 'jira.analytic.line.importer'
+
+    @property
+    def _issue_fields_to_read(self):
+        issue_fields = super()._issue_fields_to_read
+        organization_field_name = self.backend_record.organization_field_name
+        if not organization_field_name:
+            return issue_fields
+        return issue_fields + [organization_field_name]

--- a/connector_jira_servicedesk/models/jira_backend/__init__.py
+++ b/connector_jira_servicedesk/models/jira_backend/__init__.py
@@ -1,0 +1,1 @@
+from . import common

--- a/connector_jira_servicedesk/models/jira_backend/common.py
+++ b/connector_jira_servicedesk/models/jira_backend/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import models, api, fields

--- a/connector_jira_servicedesk/models/jira_backend/common.py
+++ b/connector_jira_servicedesk/models/jira_backend/common.py
@@ -1,0 +1,50 @@
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models, api, fields
+
+
+class JiraBackend(models.Model):
+    _inherit = 'jira.backend'
+
+    organization_ids = fields.One2many(
+        comodel_name='jira.organization',
+        inverse_name='backend_id',
+        string='Organizations',
+        readonly=True,
+    )
+
+    organization_field_name = fields.Char(
+        string='Organization Field',
+        help="The 'Organization' field on JIRA is a custom field. "
+             "The name of the field is something like 'customfield_10002'. "
+    )
+
+    @api.model
+    def _selection_project_template(self):
+        selection = super()._selection_project_template()
+        selection += [
+            ('Basic', 'Basic (Service Desk)'),
+            ('IT Service Desk', 'IT Service Desk (Service Desk)'),
+            ('Customer service', 'Customer Service (Service Desk)'),
+        ]
+        return selection
+
+    @api.multi
+    def import_organization(self):
+        self.env['jira.organization'].import_batch(self)
+        return True
+
+    @api.multi
+    def activate_organization(self):
+        """Get organization field name from JIRA web-service"""
+        self.ensure_one()
+        org_field = 'com.atlassian.servicedesk:sd-customer-organizations'
+        with self.work_on('jira.backend') as work:
+            adapter = work.component(usage='backend.adapter')
+            jira_fields = adapter.list_fields()
+            for field in jira_fields:
+                custom_ref = field.get('schema', {}).get('custom')
+                if custom_ref == org_field:
+                    self.organization_field_name = field['id']
+                    break

--- a/connector_jira_servicedesk/models/jira_organization/__init__.py
+++ b/connector_jira_servicedesk/models/jira_organization/__init__.py
@@ -1,0 +1,3 @@
+from . import common
+from . import importer
+from . import adapter

--- a/connector_jira_servicedesk/models/jira_organization/adapter.py
+++ b/connector_jira_servicedesk/models/jira_organization/adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import jira

--- a/connector_jira_servicedesk/models/jira_organization/adapter.py
+++ b/connector_jira_servicedesk/models/jira_organization/adapter.py
@@ -1,0 +1,61 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import jira
+from jira.utils import CaseInsensitiveDict
+
+from odoo.addons.component.core import Component
+
+
+class Organization(jira.resources.Resource):
+    """A Service Desk Organization."""
+
+    def __init__(self, options, session, raw=None):
+        super().__init__(
+            'organization/{0}',
+            options,
+            session,
+            '{server}/rest/servicedeskapi/{path}'
+        )
+        if raw:
+            self._parse_raw(raw)
+
+
+class OrganizationAdapter(Component):
+    _name = 'jira.organization.adapter'
+    _inherit = ['jira.webservice.adapter']
+    _apply_on = ['jira.organization']
+
+    # The Service Desk REST API returns an error if this header
+    # is not used. The API may change so they want an agreement for
+    # the client about this.
+    _desk_headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+
+    def __init__(self, work_context):
+        super().__init__(work_context)
+        self.client._session.headers.update(self._desk_headers)
+
+    def read(self, id_):
+        organization = Organization(
+            self.client._options,
+            self.client._session
+        )
+        organization.find(id_)
+        return organization.raw
+
+    def search(self):
+        base = (self.client._options['server'] +
+                '/rest/servicedeskapi/organization')
+        # By default, a GET on the REST API returns only one page with the
+        # first 50 rows. Here, client is an instance of the jira library's JIRA
+        # class, which provides a _fetch_pages method to fetch pages.
+        # maxResults=False means it will try to get all pages.
+        orgs = self.client._fetch_pages(
+            Organization,
+            'values',
+            'organization',
+            # limit to False will get them in batch
+            maxResults=False,
+            base=base
+        )
+        return [org.id for org in orgs]

--- a/connector_jira_servicedesk/models/jira_organization/common.py
+++ b/connector_jira_servicedesk/models/jira_organization/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 

--- a/connector_jira_servicedesk/models/jira_organization/common.py
+++ b/connector_jira_servicedesk/models/jira_organization/common.py
@@ -1,0 +1,30 @@
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+from odoo import fields, models
+from odoo.addons.queue_job.job import job
+
+
+class JiraOrganization(models.Model):
+    _name = 'jira.organization'
+    _inherit = 'jira.binding'
+    _description = 'Jira Organization'
+
+    name = fields.Char('Name', required=True, readonly=True)
+    backend_id = fields.Many2one(
+        ondelete='cascade'
+    )
+    project_ids = fields.Many2many(
+        comodel_name='jira.project.project'
+    )
+
+    @job(default_channel='root.connector_jira.import')
+    def import_batch(self, backend, from_date=None, to_date=None):
+        """ Prepare a batch import of organization from Jira
+
+        from_date and to_date are ignored for organization
+        """
+        with backend.work_on(self._name) as work:
+            importer = work.component(usage='batch.importer')
+            importer.run()

--- a/connector_jira_servicedesk/models/jira_organization/importer.py
+++ b/connector_jira_servicedesk/models/jira_organization/importer.py
@@ -1,0 +1,36 @@
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.addons.connector.components.mapper import mapping
+
+from odoo.addons.component.core import Component
+
+
+class OrganizationMapper(Component):
+    _name = 'jira.organization.mapper'
+    _inherit = ['base.import.mapper']
+    _apply_on = 'jira.organization'
+
+    direct = [
+        ('name', 'name'),
+    ]
+
+    @mapping
+    def backend_id(self, record):
+        return {'backend_id': self.backend_record.id}
+
+
+class OrganizationBatchImporter(Component):
+    """ Import the Jira Organizations
+
+    For every id in in the list of organizations, a direct import is done.
+    """
+    _name = 'jira.organization.batch.importer'
+    _inherit = 'jira.direct.batch.importer'
+    _apply_on = ['jira.organization']
+
+    def run(self):
+        """ Run the synchronization """
+        record_ids = self.backend_adapter.search()
+        for record_id in record_ids:
+            self._import_record(record_id)

--- a/connector_jira_servicedesk/models/jira_organization/importer.py
+++ b/connector_jira_servicedesk/models/jira_organization/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.connector.components.mapper import mapping

--- a/connector_jira_servicedesk/models/project_project/__init__.py
+++ b/connector_jira_servicedesk/models/project_project/__init__.py
@@ -1,0 +1,3 @@
+from . import common
+from . import binder
+from . import project_link_jira

--- a/connector_jira_servicedesk/models/project_project/binder.py
+++ b/connector_jira_servicedesk/models/project_project/binder.py
@@ -1,0 +1,74 @@
+# Copyright 2016-2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import logging
+
+from odoo import tools
+from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
+
+
+class JiraProjectBinder(Component):
+    _name = 'jira.project.binder'
+    _inherit = 'jira.binder'
+
+    _apply_on = [
+        'jira.project.project',
+    ]
+
+    def to_internal(self, external_id, unwrap=False, organizations=None):
+        """ Give the Odoo recordset for an external ID
+
+        When organizations are passed (ids are odoo ids), the binder
+        will return:
+
+        * a project linked with JIRA with the exact set of organizations
+        * if no project has the exact same set, a project linked without
+          organization set on the binding
+
+        If no organizations are passed, only project bindings
+        without organization match.
+
+        :param external_id: external ID for which we want
+                            the Odoo ID
+        :param unwrap: if True, returns the normal record
+                       else return the binding record
+        :param organizations: jira.organization recordset
+        :return: a recordset, depending on the value of unwrap,
+                 or an empty recordset if the external_id is not mapped
+        :rtype: recordset
+        """
+        domain = [
+            (self._external_field, '=', tools.ustr(external_id)),
+            (self._backend_field, '=', self.backend_record.id),
+        ]
+        if not organizations:
+            domain.append(
+                ('organization_ids', '=', False),
+            )
+        candidates = self.model.with_context(active_test=False).search(domain)
+        if organizations:
+            fallback = self.model.browse()
+            binding = self.model.browse()
+            for candidate in candidates:
+                if not candidate.organization_ids:
+                    fallback = candidate
+                    continue
+
+                if candidate.organization_ids == organizations:
+                    binding = candidate
+                    break
+            if not binding:
+                binding = fallback
+        else:
+            binding = candidates
+
+        if not binding:
+            if unwrap:
+                return self.model.browse()[self._odoo_field]
+            return self.model.browse()
+        binding.ensure_one()
+        if unwrap:
+            binding = binding[self._odoo_field]
+        return binding

--- a/connector_jira_servicedesk/models/project_project/binder.py
+++ b/connector_jira_servicedesk/models/project_project/binder.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_jira_servicedesk/models/project_project/common.py
+++ b/connector_jira_servicedesk/models/project_project/common.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models, exceptions, _
+
+
+class JiraProjectBaseFields(models.AbstractModel):
+    """JIRA Project Base fields
+
+    Shared by the binding jira.project.project
+    and the wizard to link/create a JIRA project
+    """
+    _inherit = 'jira.project.base.mixin'
+
+    organization_ids = fields.Many2many(
+        comodel_name='jira.organization',
+        string='Organization(s) on Jira',
+        domain="[('backend_id', '=', backend_id)]",
+        help="If organizations are set, a task will be "
+             "added to the project only if the project AND "
+             "the organization match with the selection."
+    )
+
+
+class JiraProjectProject(models.Model):
+    _inherit = 'jira.project.project'
+
+    @api.constrains('backend_id', 'external_id', 'organization_ids')
+    @api.multi
+    def _constrains_jira_uniq(self):
+        for binding in self:
+            same_link_bindings = self.search([
+                ('id', '!=', self.id),
+                ('backend_id', '=', self.backend_id.id),
+                ('external_id', '=', self.external_id),
+            ])
+            for other in same_link_bindings:
+                my_orgs = binding.organization_ids
+                other_orgs = other.organization_ids
+                if not my_orgs and not other_orgs:
+                    raise exceptions.ValidationError(_(
+                        "The project %s is already linked with the same"
+                        " JIRA project without organization."
+                    ) % (other.display_name))
+                if set(my_orgs.ids) == set(other_orgs.ids):
+                    raise exceptions.ValidationError(_(
+                        "The project %s is already linked with this "
+                        "JIRA project and similar organizations."
+                    ) % (other.display_name))

--- a/connector_jira_servicedesk/models/project_project/project_link_jira.py
+++ b/connector_jira_servicedesk/models/project_project/project_link_jira.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_jira_servicedesk/models/project_project/project_link_jira.py
+++ b/connector_jira_servicedesk/models/project_project/project_link_jira.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ProjectLinkJira(models.TransientModel):
+    _inherit = 'project.link.jira'
+
+    @api.model
+    def _selection_state(self):
+        states = super()._selection_state()
+        states.append(('link_organizations', 'Link Organizations'))
+        return states
+
+    def state_exit_start(self):
+        if self.sync_action == 'link':
+            self.state = 'link_organizations'
+        else:
+            super().state_exit_start()
+
+    def state_exit_link_organizations(self):
+        if not self.jira_project_id:
+            self._link_binding()
+        self.state = 'issue_types'
+
+    def _prepare_link_binding_values(self, jira_project):
+        values = super()._prepare_link_binding_values(jira_project)
+        values['organization_ids'] = [(6, 0, self.organization_ids.ids)]
+        return values

--- a/connector_jira_servicedesk/models/project_task/__init__.py
+++ b/connector_jira_servicedesk/models/project_task/__init__.py
@@ -1,0 +1,1 @@
+from . import importer

--- a/connector_jira_servicedesk/models/project_task/importer.py
+++ b/connector_jira_servicedesk/models/project_task/importer.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Camptocamp SA
+# Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.component.core import Component

--- a/connector_jira_servicedesk/models/project_task/importer.py
+++ b/connector_jira_servicedesk/models/project_task/importer.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.addons.component.core import Component
+
+
+class ProjectTaskProjectMatcher(Component):
+    _inherit = 'jira.task.project.matcher'
+
+    def find_project_binding(self, jira_task_data, unwrap=False):
+        organizations = self.env['jira.organization'].browse()
+        jira_org_ids = self.component(
+            usage='organization.from.task'
+        ).get_jira_org_ids(jira_task_data)
+        binder = self.binder_for('jira.organization')
+        for jira_org_id in jira_org_ids:
+            organizations |= binder.to_internal(jira_org_id)
+        jira_project_id = jira_task_data['fields']['project']['id']
+        binder = self.binder_for('jira.project.project')
+        return binder.to_internal(
+            jira_project_id,
+            unwrap=unwrap,
+            organizations=organizations,
+        )
+
+
+class OrganizationsFromTask(Component):
+    _name = 'jira.organization.from.task'
+    _inherit = ['jira.base']
+    _usage = 'organization.from.task'
+
+    def get_jira_org_ids(self, jira_task_data):
+        organization_field_name = self.backend_record.organization_field_name
+        if not organization_field_name:
+            return []
+
+        task_fields = jira_task_data.get('fields', {})
+        return [
+            rec['id'] for rec in
+            task_fields.get(organization_field_name) or []
+        ]
+
+
+class ProjectTaskImporter(Component):
+    _inherit = 'jira.project.task.importer'
+
+    def _get_external_data(self):
+        """Return the raw Jira data for ``self.external_id``"""
+        result = super()._get_external_data()
+        return result
+
+    def _import_dependencies(self):
+        """Import the dependencies for the record"""
+        super()._import_dependencies()
+        jira_org_ids = self.component(
+            usage='organization.from.task'
+        ).get_jira_org_ids(self.external_record)
+        for jira_org_id in jira_org_ids:
+            self._import_dependency(jira_org_id, 'jira.organization')

--- a/connector_jira_servicedesk/security/ir.model.access.csv
+++ b/connector_jira_servicedesk/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_jira_organization,access_jira_organization,model_jira_organization,base.group_user,1,0,0,0
+access_jira_organization_manager,access_jira_organization connector manager,model_jira_organization,connector.group_connector_manager,1,1,1,1

--- a/connector_jira_servicedesk/views/jira_backend_views.xml
+++ b/connector_jira_servicedesk/views/jira_backend_views.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <!-- Backend -->
+  <record id="view_jira_backend_form" model="ir.ui.view">
+    <field name="name">jira.backend.form</field>
+    <field name="model">jira.backend</field>
+    <field name="inherit_id" ref="connector_jira.view_jira_backend_form" />
+    <field name="arch" type="xml">
+      <xpath expr="(//page[@name='import']/group)[last()]" position="after">
+        <group>
+          <div>
+            <label string="Import Organizations"
+                   class="oe_inline"/>
+          </div>
+          <button name="import_organization"
+                  type="object"
+                  class="oe_highlight"
+                  string="Run"/>
+        </group>
+      </xpath>
+
+      <xpath expr="//page[@name='issue_type']" position="after">
+        <page name="organization" string="Organizations" states="running">
+          <field name="organization_ids">
+            <tree string="Jira Organization" create="0" delete="0" edit="0">
+              <field name="name"/>
+            </tree>
+            <form string="Jira Organization" create="0" delete="0" edit="0">
+              <group>
+                <field name="name"/>
+              </group>
+            </form>
+          </field>
+        </page>
+      </xpath>
+
+      <xpath expr="(//page[@name='advanced_configuration']/group)[last()]" position="after">
+        <group col="4">
+          <field name="organization_field_name"/>
+          <button name="activate_organization"
+                  type="object"
+                  string="Configure Organization"
+                  class="oe_inline"
+                  attrs="{'invisible': [('state', '=', 'authenticate')]}"/>
+          <p class="oe_grey oe_inline">
+            Activate the synchronization of the Organization field.
+            Only on JIRA ServiceDesk. The field contains the name of
+            the JIRA custom field that contains the Organization.
+          </p>
+        </group>
+      </xpath>
+    </field>
+  </record>
+</odoo>

--- a/connector_jira_servicedesk/views/project_link_jira_views.xml
+++ b/connector_jira_servicedesk/views/project_link_jira_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="project_link_jira_form" model="ir.ui.view">
+    <field name="name">project.link.jira.form</field>
+    <field name="model">project.link.jira</field>
+    <field name="inherit_id" ref="connector_jira.project_link_jira_form"/>
+    <field name="arch" type="xml">
+      <group name="export_config" position="after">
+        <group name="link_organizations" attrs="{'invisible': [('state', '!=', 'link_organizations')]}">
+          <field name="organization_ids"
+                 widget="many2many_tags"
+                 options="{'no_create': True}" 
+                 />
+          <div colspan="2">
+            <p class="oe_grey oe_inline">
+              The organizations you choose will define how the tasks and worklogs are attached to the project.
+              If a task is assigned to an organization, it will be assigned
+              to an Odoo project linked to the JIRA project only if the
+              organization match. If no project with an organization exists,
+              the task will be assigned to a linked project without organization.
+              If no such project exists in Odoo, the task is ignored.
+            </p>
+          </div>
+
+        </group>
+      </group>
+    </field>
+  </record>
+
+</odoo>

--- a/connector_jira_servicedesk/views/project_project_views.xml
+++ b/connector_jira_servicedesk/views/project_project_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="view_jira_project_project_form" model="ir.ui.view">
+    <field name="name">jira.project.project.form</field>
+    <field name="model">jira.project.project</field>
+    <field name="inherit_id" ref="connector_jira.view_jira_project_project_form" />
+    <field name="arch" type="xml">
+      <field name="external_id" position="after">
+        <field name="organization_ids"
+               widget="many2many_tags"
+               options="{'no_create': True}" />
+      </field>
+    </field>
+  </record>
+
+  <record id="view_jira_project_project_tree" model="ir.ui.view">
+    <field name="name">jira.project.project.tree</field>
+    <field name="model">jira.project.project</field>
+    <field name="inherit_id" ref="connector_jira.view_jira_project_project_tree" />
+    <field name="arch" type="xml">
+      <field name="external_id" position="after">
+        <field name="organization_ids" />
+      </field>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Now linking a project with JIRA must be done through a wizard instead of
the binding view. It must be either export (create the project on jira) or
link (link with an existing project on jira).

Project bindings now can be assigned to one or more jira organizations. The
binding for the project accept an additional argument for organizations. A
task will be linked with the project having the exact same set of
organizations that it has, or fallback to a project without organization.

A constraint ensures that you cannot have several projects with the same
set of organizations or 2 projects without organization.

![peek 2019-02-01 10-21](https://user-images.githubusercontent.com/417223/52114224-c5690280-260b-11e9-8524-df4a54fbf7ae.gif)
