### PR TITLE
Store original jira issues on analytic lines

### DIFF
--- a/connector_jira/models/account_analytic_line/importer.py
+++ b/connector_jira/models/account_analytic_line/importer.py
@@ -30,7 +30,21 @@ class AnalyticLineMapper(Component):
 
     @mapping
     def issue(self, record):
-        return {'jira_issue_id': record['issueId']}
+        issue = self.options.linked_issue
+        assert issue
+        refs = {
+            'jira_issue_id': record['issueId'],
+            'jira_issue_key': issue['key'],
+        }
+        task_mapper = self.component(
+            usage='import.mapper',
+            model_name='jira.project.task',
+        )
+        refs.update(task_mapper.issue_type(issue))
+        epic_field_name = self.backend_record.epic_link_field_name
+        if epic_field_name:
+            refs['jira_epic_issue_key'] = issue['fields'][epic_field_name]
+        return refs
 
     @mapping
     def duration(self, record):

--- a/connector_jira/views/timesheet_account_analytic_line.xml
+++ b/connector_jira/views/timesheet_account_analytic_line.xml
@@ -8,15 +8,15 @@
     <field name="arch" type="xml">
 
       <field name="task_id" position="after">
-        <field name="jira_compound_key" invisible="1" />
+        <field name="jira_issue_key" invisible="1" />
         <field name="jira_issue_url" widget="url"
-               options='{"text_field": "jira_compound_key"}'
-               attrs="{'invisible': [('jira_compound_key', '=', False)]}"/>
-        <field name="jira_epic_compound_key" invisible="1" />
+               options='{"text_field": "jira_issue_key"}'
+               attrs="{'invisible': [('jira_issue_key', '=', False)]}"/>
+        <field name="jira_epic_issue_key" invisible="1" />
         <field name="jira_epic_issue_url" widget="url"
-               options='{"text_field": "jira_epic_compound_key"}'
-               attrs="{'invisible': [('jira_epic_compound_key', '=', False)]}"/>
-        <field name="jira_issue_type" />
+               options='{"text_field": "jira_epic_issue_key"}'
+               attrs="{'invisible': [('jira_epic_issue_key', '=', False)]}"/>
+        <field name="jira_issue_type_id" />
       </field>
 
     </field>
@@ -29,13 +29,13 @@
     <field name="arch" type="xml">
 
       <field name="task_id" position="after">
-        <field name="jira_compound_key" invisible="1" />
-        <field name="jira_issue_url" widget="url" options='{"text_field": "jira_compound_key"}'
-               attrs="{'invisible': [('jira_compound_key', '=', False)]}"/>
-        <field name="jira_epic_compound_key" invisible="1" />
-        <field name="jira_epic_issue_url" widget="url" options='{"text_field":"jira_epic_compound_key"}'
-               attrs="{'invisible': [('jira_epic_compound_key', '=', False)]}"/>
-        <field name="jira_issue_type" />
+        <field name="jira_issue_key" invisible="1" />
+        <field name="jira_issue_url" widget="url" options='{"text_field": "jira_issue_key"}'
+               attrs="{'invisible': [('jira_issue_key', '=', False)]}"/>
+        <field name="jira_epic_issue_key" invisible="1" />
+        <field name="jira_epic_issue_url" widget="url" options='{"text_field":"jira_epic_issue_key"}'
+               attrs="{'invisible': [('jira_epic_issue_key', '=', False)]}"/>
+        <field name="jira_issue_type_id" />
       </field>
 
     </field>
@@ -49,14 +49,14 @@
       <field name="arch" type="xml">
 
         <field name="task_id" position="after">
-          <field name="jira_compound_key" string="JIRA issue" />
-          <field name="jira_epic_compound_key" string="JIRA Epic" />
+          <field name="jira_issue_key" string="JIRA issue" />
+          <field name="jira_epic_issue_key" string="JIRA Epic" />
 
         </field>
         <filter name="groupby_date" position="after">
-          <filter string="JIRA issue" name="groupby_jira_task" domain="[]" context="{'group_by':'jira_compound_key'}"/>
-          <filter string="JIRA epic" name="groupby_jira_epic" domain="[]" context="{'group_by':'jira_epic_compound_key'}"/>
-          <filter string="JIRA issue type" name="groupby_jira_type" domain="[]" context="{'group_by':'jira_issue_type'}"/>
+          <filter string="JIRA Original Issue" name="groupby_jira_task" domain="[]" context="{'group_by':'jira_issue_key'}"/>
+          <filter string="JIRA Original Epic" name="groupby_jira_epic" domain="[]" context="{'group_by':'jira_epic_issue_key'}"/>
+          <filter string="JIRA Original Issue Type" name="groupby_jira_type" domain="[]" context="{'group_by':'jira_issue_type_id'}"/>
         </filter>
 
     </field>


### PR DESCRIPTION
Instead of the issue they are linked to in Odoo.
With the mechanism in place, if we don't import the task or bug issue
types and we synchronize the epics, the worklogs will be attached to the
epics of their tasks (of subtasks to tasks). The fields were showing the
values of the Epic (or task for subtask), though it makes much more
sense to keep the keys and URLs of the original issue and epic on the
analytic lines. We still have the link to the task if we want to get the
URL for the task they are currently linked to.