### PR TITLE
Allow to have one project binding per project type

### DIFF
--- a/connector_jira/__manifest__.py
+++ b/connector_jira/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 {'name': 'JIRA Connector',
- 'version': '11.0.1.0.0',
+ 'version': '11.0.1.1.0',
  'author': 'Camptocamp,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Connector',

--- a/connector_jira/components/backend_adapter.py
+++ b/connector_jira/components/backend_adapter.py
@@ -3,6 +3,12 @@
 
 import logging
 
+from contextlib import contextmanager
+
+import jira
+import requests
+
+from odoo import _, exceptions
 from odoo.addons.component.core import Component
 
 _logger = logging.getLogger(__name__)
@@ -19,4 +25,29 @@ class JiraAdapter(Component):
 
     def __init__(self, work_context):
         super().__init__(work_context)
-        self.client = self.backend_record.get_api_client()
+        self._client = None
+
+    @property
+    def client(self):
+        # lazy load the client, initialize only when actually needed
+        if not self._client:
+            self._client = self.backend_record.get_api_client()
+        return self._client
+
+    @contextmanager
+    def handle_user_api_errors(self):
+        """Contextmanager to use when the API is used user-side
+
+        It catches the common network or Jira errors and reraise them
+        to the user using the Odoo UserError.
+        """
+        try:
+            yield
+        except requests.exceptions.ConnectionError as err:
+            _logger.exception('Jira ConnectionError')
+            message = _('Error during connection with Jira: %s') % (err,)
+            raise exceptions.UserError(message)
+        except jira.exceptions.JIRAError as err:
+            _logger.exception('Jira JIRAError')
+            message = _('Jira Error: %s') % (err,)
+            raise exceptions.UserError(message)

--- a/connector_jira/migrations/11.0.1.1.0/pre-migration.py
+++ b/connector_jira/migrations/11.0.1.1.0/pre-migration.py
@@ -1,0 +1,41 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute("""
+       ALTER TABLE jira_project_project
+       DROP CONSTRAINT IF EXISTS
+       jira_project_project_jira_binding_backend_uniq;
+    """)
+
+    # copy the jira_key from project to binding before we change it
+    # as a computed field
+    cr.execute("""
+        ALTER TABLE jira_project_project
+        ADD COLUMN jira_key VARCHAR(10);
+    """)
+    cr.execute("""
+        UPDATE jira_project_project
+        SET jira_key = project_project.jira_key
+        FROM project_project
+        WHERE project_project.id = jira_project_project.odoo_id;
+    """)
+    cr.execute("""
+        ALTER TABLE jira_project_project
+        DROP COLUMN jira_key;
+    """)
+
+    cr.execute("""
+        ALTER TABLE jira_project_project
+        ADD COLUMN project_type VARCHAR;
+    """)
+    # we don't know the correct value, set software by default
+    # until 11.0.1.1.0 we cannot have more than one binding,
+    # so the constraint will not fail anyway
+    cr.execute("""
+        UPDATE jira_project_project
+        SET project_type = 'software';
+    """)

--- a/connector_jira/models/project_project/__init__.py
+++ b/connector_jira/models/project_project/__init__.py
@@ -1,3 +1,4 @@
+from . import binder
 from . import common
 from . import project_link_jira
 from . import exporter

--- a/connector_jira/models/project_project/binder.py
+++ b/connector_jira/models/project_project/binder.py
@@ -40,7 +40,7 @@ class JiraProjectBinder(Component):
             binding = self.model.with_context(active_test=False).search(
                 [(self._odoo_field, '=', binding.id),
                  (self._backend_field, '=', self.backend_record.id),
-                 (self.project_type, '=', project_type),
+                 ('project_type', '=', project_type),
                  ]
             )
             if not binding:

--- a/connector_jira/models/project_project/binder.py
+++ b/connector_jira/models/project_project/binder.py
@@ -1,0 +1,50 @@
+# Copyright 2016-2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import logging
+
+from odoo import models
+from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
+
+
+class JiraProjectBinder(Component):
+    _name = 'jira.project.binder'
+    _inherit = 'jira.binder'
+
+    _apply_on = [
+        'jira.project.project',
+    ]
+
+    def to_external(self, binding, wrap=False):
+        """ Give the external ID for an Odoo binding ID
+
+        More than one jira binding is tolerated on projects, but regarding the
+        exports, we flag only one of them as master for the exports. The master
+        binding is either the binding with the sync action "export", or if no
+        binding is using the export action, this is the one flagged
+        "is_master".
+
+        :param binding: Odoo binding for which we want the external id
+        :param wrap: if True, binding is a normal record, the
+                     method will search the corresponding binding and return
+                     the external id of the binding
+        :return: external ID of the record
+        """
+        if isinstance(binding, models.BaseModel):
+            binding.ensure_one()
+        else:
+            binding = self.model.browse(binding)
+        if wrap:
+            binding = self.model.with_context(active_test=False).search(
+                [(self._odoo_field, '=', binding.id),
+                 (self._backend_field, '=', self.backend_record.id),
+                 (self.is_master, '=', True),
+                 ]
+            )
+            if not binding:
+                return None
+            binding.ensure_one()
+            return binding[self._external_field]
+        return binding[self._external_field]

--- a/connector_jira/models/project_project/binder.py
+++ b/connector_jira/models/project_project/binder.py
@@ -17,14 +17,12 @@ class JiraProjectBinder(Component):
         'jira.project.project',
     ]
 
-    def to_external(self, binding, wrap=False):
+    def to_external(self, binding, wrap=False, project_type=None):
         """ Give the external ID for an Odoo binding ID
 
-        More than one jira binding is tolerated on projects, but regarding the
-        exports, we flag only one of them as master for the exports. The master
-        binding is either the binding with the sync action "export", or if no
-        binding is using the export action, this is the one flagged
-        "is_master".
+        More than one jira binding is tolerated on projects, but we can have
+        only one binding for each type of project (software, service_desk,
+        business, ...).
 
         :param binding: Odoo binding for which we want the external id
         :param wrap: if True, binding is a normal record, the
@@ -32,6 +30,8 @@ class JiraProjectBinder(Component):
                      the external id of the binding
         :return: external ID of the record
         """
+        if not project_type:
+            raise ValueError('project_type argument is required')
         if isinstance(binding, models.BaseModel):
             binding.ensure_one()
         else:
@@ -40,7 +40,7 @@ class JiraProjectBinder(Component):
             binding = self.model.with_context(active_test=False).search(
                 [(self._odoo_field, '=', binding.id),
                  (self._backend_field, '=', self.backend_record.id),
-                 (self.is_master, '=', True),
+                 (self.project_type, '=', project_type),
                  ]
             )
             if not binding:

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -20,20 +20,17 @@ class ProjectLinkJira(models.TransientModel):
         name="Project",
         required=True,
         ondelete='cascade',
-        default=lambda self: self._default_project_id(),
     )
     jira_key = fields.Char(
         string='JIRA Key',
         size=10,  # limit on JIRA
         required=True,
-        default=lambda self: self._default_jira_key(),
     )
     backend_id = fields.Many2one(
         comodel_name='jira.backend',
         string='Jira Backend',
         required=True,
         ondelete='cascade',
-        default=lambda self: self._default_backend_id(),
     )
     jira_project_id = fields.Many2one(
         comodel_name='jira.project.project',
@@ -50,26 +47,39 @@ class ProjectLinkJira(models.TransientModel):
         ]
 
     @api.model
-    def _default_project_id(self):
-        return self.env.context.get('active_id')
-
-    @api.model
-    def _default_jira_key(self):
-        project_id = self._default_project_id()
+    def default_get(self, fields):
+        values = super().default_get(fields)
+        context = self.env.context
+        project_id = context.get('active_id')
         if not project_id:
-            return
+            return values
+
         project = self.env['project.project'].browse(project_id)
         if project.jira_key:
-            return project.jira_key
-        valid = self.env['jira.project.project']._jira_key_valid
-        if valid(project.name):
-            return project.name
+            values['jira_key'] = project.jira_key
+        else:
+            valid = self.env['jira.project.project']._jira_key_valid
+            if valid(project.name):
+                values['jira_key'] = project.name
 
-    @api.model
-    def _default_backend_id(self):
+        values.update({
+            'project_id': project_id,
+        })
+
         backends = self.env['jira.backend'].search([])
         if len(backends) == 1:
-            return backends.id
+            values['backend_id'] = backends.id
+
+            jira_project_model = self.env['jira.project.project']
+            new_binding = jira_project_model.new({
+                'odoo_id': values['project_id'],
+                'backend_id': values['backend_id'],
+            })
+            domain = new_binding._other_master_domain()
+            if not jira_project_model.search(domain):
+                values['is_master'] = True
+
+        return values
 
     @api.constrains('jira_key')
     def check_jira_key(self):
@@ -106,16 +116,26 @@ class ProjectLinkJira(models.TransientModel):
             self._create_export_binding()
         self.state = 'final'
 
-    def _prepare_export_binding_values(self):
+    def _prepare_base_binding_values(self):
         values = {
             'backend_id': self.backend_id.id,
             'odoo_id': self.project_id.id,
-            'jira_key': self.jira_key,
+            'is_master': self.is_master,
+        }
+        if self.is_master:
+            values['jira_key'] = self.jira_key
+        return values
+
+    def _prepare_export_binding_values(self):
+        values = self._prepare_base_binding_values()
+        values.update({
+            'backend_id': self.backend_id.id,
+            'odoo_id': self.project_id.id,
             'sync_action': 'export',
             'sync_issue_type_ids': [(6, 0, self.sync_issue_type_ids.ids)],
             'project_template': self.project_template,
             'project_template_shared': self.project_template_shared,
-        }
+        })
         return values
 
     def _create_export_binding(self):
@@ -151,13 +171,11 @@ class ProjectLinkJira(models.TransientModel):
         self.sync_issue_type_ids = issue_types.ids
 
     def _prepare_link_binding_values(self, jira_project):
-        values = {
-            'backend_id': self.backend_id.id,
-            'odoo_id': self.project_id.id,
-            'jira_key': self.jira_key,
+        values = self._prepare_base_binding_values()
+        values.update({
             'sync_action': self.sync_action,
             'external_id': jira_project.id,
-        }
+        })
         return values
 
     def _copy_issue_types(self):

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -128,15 +128,8 @@ class ProjectLinkJira(models.TransientModel):
     def _link_binding(self):
         with self.backend_id.work_on('jira.project.project') as work:
             adapter = work.component(usage='backend.adapter')
-            try:
+            with adapter.handle_user_api_errors():
                 jira_project = adapter.get(self.jira_key)
-            except jira.exceptions.JIRAError:
-                _logger.exception('Error when linking to project %s',
-                                  self.project_id.id)
-                raise exceptions.UserError(
-                    _('Could not link %s, check that this project'
-                      ' keys exists in JIRA.') % (self.jira_key)
-                )
             self._link_with_jira_project(work, jira_project)
 
     def _link_with_jira_project(self, work, jira_project):

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -23,9 +23,6 @@ class ProjectLinkJira(models.TransientModel):
         default=lambda self: self._default_project_id(),
     )
     jira_key = fields.Char(
-        string='JIRA Key',
-        size=10,  # limit on JIRA
-        required=True,
         default=lambda self: self._default_jira_key(),
     )
     backend_id = fields.Many2one(
@@ -50,8 +47,6 @@ class ProjectLinkJira(models.TransientModel):
         if not project_id:
             return
         project = self.env['project.project'].browse(project_id)
-        if project.jira_key:
-            return project.jira_key
         valid = self.env['jira.project.project']._jira_key_valid
         if valid(project.name):
             return project.name

--- a/connector_jira/models/project_project/project_link_jira.py
+++ b/connector_jira/models/project_project/project_link_jira.py
@@ -3,8 +3,6 @@
 
 import logging
 
-import jira
-
 from odoo import api, fields, models, exceptions, _
 
 _logger = logging.getLogger(__name__)

--- a/connector_jira/models/project_task/task_link_jira.py
+++ b/connector_jira/models/project_task/task_link_jira.py
@@ -3,9 +3,7 @@
 
 import logging
 
-import jira
-
-from odoo import api, fields, models, exceptions, _
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 

--- a/connector_jira/models/project_task/task_link_jira.py
+++ b/connector_jira/models/project_task/task_link_jira.py
@@ -73,15 +73,8 @@ class TaskLinkJira(models.TransientModel):
     def _link_binding(self):
         with self.backend_id.work_on('jira.project.task') as work:
             adapter = work.component(usage='backend.adapter')
-            try:
+            with adapter.handle_user_api_errors():
                 jira_task = adapter.get(self.jira_key)
-            except jira.exceptions.JIRAError:
-                _logger.exception('Error when linking to task %s',
-                                  self.task_id.id)
-                raise exceptions.UserError(
-                    _('Could not link %s, check that this task'
-                      ' keys exists in JIRA.') % (self.jira_key)
-                )
             self._link_with_jira_task(work, jira_task)
             self._run_import_jira_task(work, jira_task)
 

--- a/connector_jira/views/project_link_jira_views.xml
+++ b/connector_jira/views/project_link_jira_views.xml
@@ -18,6 +18,7 @@
           <group>
             <field name="backend_id"/>
             <field name="sync_action" widget="radio"/>
+            <field name="is_master"/>
           </group>
         </group>
         <group name="issue_types" attrs="{'invisible': [('state', '!=', 'issue_types')]}">

--- a/connector_jira/views/project_link_jira_views.xml
+++ b/connector_jira/views/project_link_jira_views.xml
@@ -18,7 +18,6 @@
           <group>
             <field name="backend_id"/>
             <field name="sync_action" widget="radio"/>
-            <field name="is_master"/>
           </group>
         </group>
         <group name="issue_types" attrs="{'invisible': [('state', '!=', 'issue_types')]}">

--- a/connector_jira/views/project_project_views.xml
+++ b/connector_jira/views/project_project_views.xml
@@ -37,7 +37,7 @@
                     'invisible': [('project_template', '!=', 'shared')],
                     'required': [('project_template', '=', 'shared')]}"/>
           <field name="sync_action"/>
-          <field name="is_master"/>
+          <field name="project_type"/>
           <div colspan="2">
             <p class="oe_grey oe_inline">
               The checkboxes define which types of JIRA issues will be imported
@@ -80,7 +80,7 @@
       <tree string="Jira Project" create="0">
         <field name="backend_id"/>
         <field name="external_id"/>
-        <field name="is_master"/>
+        <field name="project_type"/>
         <field name="sync_issue_type_ids"/>
       </tree>
     </field>

--- a/connector_jira/views/project_project_views.xml
+++ b/connector_jira/views/project_project_views.xml
@@ -16,8 +16,7 @@
       </xpath>
 
       <field name="partner_id" position="before">
-        <field name="jira_exportable" invisible="1"/>
-        <field name="jira_key" attrs="{'required': [('jira_exportable', '=', True)]}"/>
+        <field name="jira_key"/>
       </field>
     </field>
   </record>
@@ -28,6 +27,7 @@
     <field name="arch" type="xml">
       <form string="Jira Project">
         <group>
+          <field name="jira_key"/>
           <field name="backend_id"
             attrs="{'readonly': [('external_id', '!=', False)]}"/>
           <field name="project_template"
@@ -79,6 +79,7 @@
     <field name="arch" type="xml">
       <tree string="Jira Project" create="0">
         <field name="backend_id"/>
+        <field name="jira_key"/>
         <field name="external_id"/>
         <field name="project_type"/>
         <field name="sync_issue_type_ids"/>

--- a/connector_jira/views/project_project_views.xml
+++ b/connector_jira/views/project_project_views.xml
@@ -37,6 +37,7 @@
                     'invisible': [('project_template', '!=', 'shared')],
                     'required': [('project_template', '=', 'shared')]}"/>
           <field name="sync_action"/>
+          <field name="is_master"/>
           <div colspan="2">
             <p class="oe_grey oe_inline">
               The checkboxes define which types of JIRA issues will be imported
@@ -79,6 +80,7 @@
       <tree string="Jira Project" create="0">
         <field name="backend_id"/>
         <field name="external_id"/>
+        <field name="is_master"/>
         <field name="sync_issue_type_ids"/>
       </tree>
     </field>

--- a/connector_jira_servicedesk/models/project_project/binder.py
+++ b/connector_jira_servicedesk/models/project_project/binder.py
@@ -10,12 +10,7 @@ _logger = logging.getLogger(__name__)
 
 
 class JiraProjectBinder(Component):
-    _name = 'jira.project.binder'
-    _inherit = 'jira.binder'
-
-    _apply_on = [
-        'jira.project.project',
-    ]
+    _inherit = 'jira.project.binder'
 
     def to_internal(self, external_id, unwrap=False, organizations=None):
         """ Give the Odoo recordset for an external ID

--- a/connector_jira_servicedesk/models/project_project/common.py
+++ b/connector_jira_servicedesk/models/project_project/common.py
@@ -25,6 +25,12 @@ class JiraProjectBaseFields(models.AbstractModel):
 class JiraProjectProject(models.Model):
     _inherit = 'jira.project.project'
 
+    @api.model
+    def _selection_project_type(self):
+        selection = super()._selection_project_type()
+        selection.append(('service_desk', 'Service Desk'))
+        return selection
+
     @api.constrains('backend_id', 'external_id', 'organization_ids')
     @api.multi
     def _constrains_jira_uniq(self):

--- a/connector_jira_servicedesk/models/project_project/common.py
+++ b/connector_jira_servicedesk/models/project_project/common.py
@@ -28,6 +28,15 @@ class JiraProjectProject(models.Model):
     @api.constrains('backend_id', 'external_id', 'organization_ids')
     @api.multi
     def _constrains_jira_uniq(self):
+        """Modify the base constraint by adding organizations
+
+        Rather than checking unicity of backend+jira id, we validate
+        backend+jira id+organizations ids.
+
+        It allows to have different odoo projects depending of the
+        organization used on Jira.
+
+        """
         for binding in self:
             if not binding.external_id:
                 continue


### PR DESCRIPTION
The unicity constraint (backend_id, odoo_id) on jira.backend.backend is
relaxed: it now allows one binding of each type. The reason for this is:

* supporting several projects of different types is a requirements (eg.
 1 service desk and 1 software)
* but if we implement new features like "if I create a task it is
 pushed to Jira", with different projects we would not know where to
 push them

Using this constraint, we'll be able to focus new export features by
project type.

Changes needed for this:

* add a field for storing the jira project type (software, business, service_desk)
* implement the constraint
* move the jira_key field from project.project to jira.project.project (bindings)
* compute ProjectProject.jira_key from the related bindings by joining them
* add a migration script to move the jira_key data
* an unrelated improvement: in the wizards to link project/tasks, add a context
  manager to properly handle the errors facing users