### PR TITLE
Fix error when several odoo users match

### DIFF
--- a/connector_jira/models/res_users/importer.py
+++ b/connector_jira/models/res_users/importer.py
@@ -1,7 +1,9 @@
 # Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from odoo import _
 from odoo.addons.component.core import Component
+from odoo.addons.queue_job.exception import JobError
 
 
 class UserImporter(Component):
@@ -21,4 +23,16 @@ class UserImporter(Component):
                  ('login', '=', jira_key),
                  ('email', '=', email)],
             )
+            if len(user) > 1:
+                raise JobError(
+                    _("Several users found (%s) for jira account %s (%s)."
+                      " Please link it manually from the Odoo user's form.")
+                    % (user.mapped('login'), jira_key, email)
+                )
+            elif not user:
+                raise JobError(
+                    _("No user found for jira account %s (%s)."
+                      " Please link it manually from the Odoo user's form.")
+                    % (jira_key, email)
+                )
             return user.link_with_jira(backends=self.backend_record)


### PR DESCRIPTION
When we are importing a worklog for a user not yet linked and we found
several candidate users in odoo, they will both be linked with the same
jira user and make the unicity constraint fail.

Properly raise an error in this case.