### PR TITLE
Add related action to open jira with import issues

### DIFF
--- a/connector_jira/models/__init__.py
+++ b/connector_jira/models/__init__.py
@@ -6,3 +6,4 @@ from . import jira_issue_type
 from . import project_project
 from . import project_task
 from . import res_users
+from . import queue_job

--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models
-from odoo.addons.queue_job.job import job
+from odoo.addons.queue_job.job import job, related_action
 
 from odoo.addons.component.core import Component
 
@@ -66,6 +66,7 @@ class JiraAccountAnalyticLine(models.Model):
             )
 
     @job(default_channel='root.connector_jira.import')
+    @related_action(action="related_action_jira_link")
     @api.model
     def import_record(self, backend, issue_id, worklog_id, force=False):
         """ Import a worklog from JIRA """

--- a/connector_jira/models/jira_binding/common.py
+++ b/connector_jira/models/jira_binding/common.py
@@ -39,6 +39,7 @@ class JiraBinding(models.AbstractModel):
             importer.run(from_date=from_date, to_date=to_date)
 
     @job(default_channel='root.connector_jira.import')
+    @related_action(action="related_action_jira_link")
     @api.model
     def import_record(self, backend, external_id, force=False):
         """ Import a record """

--- a/connector_jira/models/queue_job/__init__.py
+++ b/connector_jira/models/queue_job/__init__.py
@@ -1,0 +1,1 @@
+from . import common

--- a/connector_jira/models/queue_job/common.py
+++ b/connector_jira/models/queue_job/common.py
@@ -1,0 +1,39 @@
+# Copyright 2016-2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, models
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.multi
+    def related_action_jira_link(self):
+        """Open a jira url for an issue """
+        self.ensure_one()
+
+        model_name = self.model_name
+        # only tested on issues so far
+        issue_models = ('jira.project.task', 'jira.account.analytic.line')
+        if model_name not in issue_models:
+            return
+
+        backend = self.args[0]
+        jira_id = self.args[1]
+
+        # Get the key of the issue to generate the URI.
+        # JIRA doesn't have an URI to show an issue by id.
+        # And at this point, we may be importing a Jira record
+        # that is not yet imported in Odoo or fails to import,
+        # so we cannot use the URL computed on the Jira binding.
+        with backend.work_on('jira.project.task') as work:
+            adapter = work.component(usage='backend.adapter')
+            with adapter.handle_user_api_errors():
+                jira_record = adapter.get(jira_id)
+        jira_key = jira_record.key
+
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'new',
+            'url': backend.make_issue_url(jira_key),
+        }


### PR DESCRIPTION
The 'related' button on jobs which import issues or worklog will now
open jira directly on the issue.