### PR TITLE
Add fallback project for worklogs

### DIFF
--- a/connector_jira/__manifest__.py
+++ b/connector_jira/__manifest__.py
@@ -39,6 +39,7 @@
      'views/res_users_views.xml',
      'views/jira_issue_type_views.xml',
      'views/timesheet_account_analytic_line.xml',
+     'wizards/jira_account_analytic_line_import_views.xml',
      'security/ir.model.access.csv',
      'data/cron.xml',
      ],

--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -81,6 +81,16 @@ class JiraAccountAnalyticLine(models.Model):
             importer = work.component(usage='record.deleter')
             importer.run(worklog_id)
 
+    @api.multi
+    def force_reimport(self):
+        for binding in self.jira_bind_ids:
+            binding.with_delay(priority=8).import_record(
+                binding.backend_id,
+                binding.jira_issue_id,
+                binding.external_id,
+                force=True,
+            )
+
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'

--- a/connector_jira/models/jira_backend/common.py
+++ b/connector_jira/models/jira_backend/common.py
@@ -72,7 +72,10 @@ class JiraBackend(models.Model):
         comodel_name="project.project",
         string="Fallback for Worklogs",
         help="Worklogs which could not be linked to any project "
-             "will be created in this project."
+             "will be created in this project. Worklogs landing in "
+             "the fallback project can be reassigned to the correct "
+             "project by: 1. linking the expected project with the Jira one, "
+             "2. using 'Refresh Worklogs from Jira' on the timesheet lines."
     )
     state = fields.Selection(
         selection=[('authenticate', 'Authenticate'),

--- a/connector_jira/models/jira_backend/common.py
+++ b/connector_jira/models/jira_backend/common.py
@@ -68,6 +68,12 @@ class JiraBackend(models.Model):
         required=True,
         default=lambda self: self._default_company(),
     )
+    worklog_fallback_project_id = fields.Many2one(
+        comodel_name="project.project",
+        string="Fallback for Worklogs",
+        help="Worklogs which could not be linked to any project "
+             "will be created in this project."
+    )
     state = fields.Selection(
         selection=[('authenticate', 'Authenticate'),
                    ('setup', 'Setup'),

--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -125,6 +125,9 @@ class ProjectTaskProjectMatcher(Component):
         binder = self.binder_for('jira.project.project')
         return binder.to_internal(jira_project_id, unwrap=unwrap)
 
+    def fallback_project_for_worklogs(self):
+        return self.backend_record.worklog_fallback_project_id
+
 
 class ProjectTaskImporter(Component):
     _name = 'jira.project.task.importer'

--- a/connector_jira/views/jira_backend_views.xml
+++ b/connector_jira/views/jira_backend_views.xml
@@ -49,6 +49,7 @@
           </group>
           <group name="main_configuration" string="Main Configuration">
             <field name="company_id"/>
+            <field name="worklog_fallback_project_id"/>
             <field name="project_template"/>
             <field name="project_template_shared"
               attrs="{'invisible': [('project_template', '!=', 'shared')],

--- a/connector_jira/views/timesheet_account_analytic_line.xml
+++ b/connector_jira/views/timesheet_account_analytic_line.xml
@@ -62,5 +62,4 @@
     </field>
   </record>
 
-
 </odoo>

--- a/connector_jira/wizards/__init__.py
+++ b/connector_jira/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import jira_backend_auth
+from . import jira_account_analytic_line_import
 from . import project_task_merge_wizard

--- a/connector_jira/wizards/jira_account_analytic_line_import.py
+++ b/connector_jira/wizards/jira_account_analytic_line_import.py
@@ -1,0 +1,26 @@
+# Copyright 2016-2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, models
+
+
+class JiraAccountAnalyticLineImport(models.TransientModel):
+    _name = 'jira.account.analytic.line.import'
+    _description = "Reimport Jira Worklogs"
+
+    @api.multi
+    def confirm(self):
+        self.ensure_one()
+        model_name = self.env.context.get('active_model')
+        record_ids = self.env.context.get('active_ids', [])
+        if model_name == 'account.analytic.line':
+            lines = self.env['account.analytic.line'].browse(record_ids)
+            bindings = lines.mapped('jira_bind_ids')
+        elif model_name == 'jira.account.analytic.line':
+            bindings = self.env['jira.account.analytic.line'].browse(
+                record_ids
+            )
+        else:
+            return
+
+        bindings.force_reimport()

--- a/connector_jira/wizards/jira_account_analytic_line_import_views.xml
+++ b/connector_jira/wizards/jira_account_analytic_line_import_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="view_jira_aa_line_import" model="ir.ui.view">
+    <field name="name">Refresh Worklogs from Jira</field>
+    <field name="model">jira.account.analytic.line.import</field>
+    <field name="arch" type="xml">
+      <form string="Reimport lines">
+        <p>
+          At confirmation, the selected lines will be reimported from Jira in
+          background. If a line was linked to the wrong project (e.g. the fallback
+          project) and the project binding has been corrected meanwhile, the line
+          will be moved to the expected target project.
+        </p>
+        <footer>
+          <button name="confirm" string="Confirm" type="object" class="btn-primary" />
+          <button string="Cancel" special="cancel" class="btn-default"/>
+        </footer>
+      </form>
+    </field>
+  </record>
+
+  <record id="action_jira_aa_line_import" model="ir.actions.act_window">
+    <field name="name">Refresh Worklogs from Jira</field>
+    <field name="res_model">jira.account.analytic.line.import</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="view_id" ref="view_jira_aa_line_import"/>
+    <field name="target">new</field>
+    <field name="binding_model_id" ref="account.model_account_analytic_line" />
+  </record>
+
+</odoo>


### PR DESCRIPTION
A new optional field on the backend allows to choose a fallback project for
the worklogs. When a worklog doesn't match any project linked with Jira,
they will be created there, allowing to find the misconfigurations and fix
them.

A new action "Refresh Worklogs from Jira" on analytic lines is meant mainly to
be used when a worklog has been imported in the fallback project and we need to
re-affect them to the correct project after we linked it.