### PR TITLE
Skip import of tasks/worklogs before batch dates

### DIFF
--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -72,7 +72,7 @@ class JiraAccountAnalyticLine(models.Model):
         """ Import a worklog from JIRA """
         with backend.work_on(self._name) as work:
             importer = work.component(usage='record.importer')
-            importer.run(worklog_id, issue_id=issue_id, force=force)
+            return importer.run(worklog_id, issue_id=issue_id, force=force)
 
     @job(default_channel='root.connector_jira.import')
     @api.model
@@ -80,7 +80,7 @@ class JiraAccountAnalyticLine(models.Model):
         """ Delete a local worklog which has been deleted on JIRA """
         with backend.work_on(self._name) as work:
             importer = work.component(usage='record.deleter')
-            importer.run(worklog_id)
+            return importer.run(worklog_id)
 
 
 class AccountAnalyticLine(models.Model):

--- a/connector_jira/models/account_analytic_line/importer.py
+++ b/connector_jira/models/account_analytic_line/importer.py
@@ -8,7 +8,9 @@ from odoo.addons.connector.exception import MappingError
 from odoo.addons.connector.components.mapper import mapping, only_create
 from odoo.addons.component.core import Component
 from ...components.backend_adapter import JIRA_JQL_DATETIME_FORMAT
-from ...components.mapper import iso8601_local_date, whenempty
+from ...components.mapper import (
+    iso8601_local_date, iso8601_to_utc_datetime, whenempty
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -128,11 +130,20 @@ class AnalyticLineImporter(Component):
     _inherit = 'jira.importer'
     _apply_on = ['jira.account.analytic.line']
 
+    _batch_import_date_field = 'import_analytic_line_from_date'
+
     def __init__(self, work_context):
         super().__init__(work_context)
         self.external_issue_id = None
         self.task_binding = None
         self.project_binding = None
+
+    def _get_external_updated_at(self):
+        assert self.external_record
+        external_updated_at = self.external_record.get('updated')
+        if not external_updated_at:
+            return None
+        return iso8601_to_utc_datetime(external_updated_at)
 
     @property
     def _issue_fields_to_read(self):

--- a/connector_jira/models/jira_binding/common.py
+++ b/connector_jira/models/jira_binding/common.py
@@ -36,7 +36,7 @@ class JiraBinding(models.AbstractModel):
         """ Prepare import of a batch of records """
         with backend.work_on(self._name) as work:
             importer = work.component(usage='batch.importer')
-            importer.run(from_date=from_date, to_date=to_date)
+            return importer.run(from_date=from_date, to_date=to_date)
 
     @job(default_channel='root.connector_jira.import')
     @related_action(action="related_action_jira_link")
@@ -45,7 +45,7 @@ class JiraBinding(models.AbstractModel):
         """ Import a record """
         with backend.work_on(self._name) as work:
             importer = work.component(usage='record.importer')
-            importer.run(external_id, force=force)
+            return importer.run(external_id, force=force)
 
     @job(default_channel='root.connector_jira.import')
     @api.model
@@ -53,7 +53,7 @@ class JiraBinding(models.AbstractModel):
         """ Delete a record on Odoo """
         with backend.work_on(self._name) as work:
             importer = work.component(usage='record.deleter')
-            importer.run(external_id)
+            return importer.run(external_id)
 
     @job(default_channel='root.connector_jira.export')
     @related_action(action='related_action_unwrap_binding')
@@ -62,4 +62,4 @@ class JiraBinding(models.AbstractModel):
         self.ensure_one()
         with self.backend_id.work_on(self._name) as work:
             exporter = work.component(usage='record.exporter')
-            exporter.run(self, fields=fields)
+            return exporter.run(self, fields=fields)

--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -131,6 +131,8 @@ class ProjectTaskImporter(Component):
     _inherit = ['jira.importer']
     _apply_on = ['jira.project.task']
 
+    _batch_import_date_field = 'import_project_task_from_date'
+
     def __init__(self, work_context):
         super().__init__(work_context)
         self.jira_epic = None


### PR DESCRIPTION
Jira may send webhooks for old records, for instance worklogs from 6
month ago because their task has been changed. This change ensures
that we never import any record which has a last update date before the
last date of batch import.

The job methods now return the result of Importer.run() so the result is
shown on the jobs in the UI.