### PR TITLE
Fix import of subtasks

### DIFF
--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -208,8 +208,7 @@ class ProjectTaskImporter(Component):
         jira_parent = self.external_record['fields'].get('parent')
         if jira_parent:
             jira_parent_id = jira_parent['id']
-            self._import_dependency(jira_parent_id, 'jira.project.task',
-                                    record=jira_parent)
+            self._import_dependency(jira_parent_id, 'jira.project.task')
 
         if self.jira_epic:
             self._import_dependency(self.jira_epic['id'], 'jira.project.task',


### PR DESCRIPTION
When importing the parent of a subtask, the record in the 'parent' field
(the task data) is incomplete, it contains only a few fields. Providing
only the id to the dependency Importer will force it to read the whole
record from Jira.