### PR TITLE
Prevent duplicates with inactive projects

### DIFF
--- a/connector_jira/models/project_project/common.py
+++ b/connector_jira/models/project_project/common.py
@@ -147,7 +147,9 @@ class JiraProjectProject(models.Model):
         Odoo to Jira (add tasks, ...).
         """
         for binding in self:
-            same_link_bindings = self.search(self._other_same_type_domain())
+            same_link_bindings = self.with_context(active_test=False).search(
+                self._other_same_type_domain()
+            )
             if same_link_bindings:
                 raise exceptions.ValidationError(_(
                     "The project \"%s\" already has a binding with "
@@ -164,7 +166,7 @@ class JiraProjectProject(models.Model):
         for binding in self:
             if not binding.external_id:
                 continue
-            same_link_bindings = self.search([
+            same_link_bindings = self.with_context(active_test=False).search([
                 ('id', '!=', binding.id),
                 ('backend_id', '=', binding.backend_id.id),
                 ('external_id', '=', binding.external_id),

--- a/connector_jira_servicedesk/models/project_project/binder.py
+++ b/connector_jira_servicedesk/models/project_project/binder.py
@@ -63,6 +63,7 @@ class JiraProjectBinder(Component):
             if unwrap:
                 return self.model.browse()[self._odoo_field]
             return self.model.browse()
+
         binding.ensure_one()
         if unwrap:
             binding = binding[self._odoo_field]

--- a/connector_jira_servicedesk/models/project_project/common.py
+++ b/connector_jira_servicedesk/models/project_project/common.py
@@ -46,7 +46,7 @@ class JiraProjectProject(models.Model):
         for binding in self:
             if not binding.external_id:
                 continue
-            same_link_bindings = self.search([
+            same_link_bindings = self.with_context(active_test=False).search([
                 ('id', '!=', binding.id),
                 ('backend_id', '=', binding.backend_id.id),
                 ('external_id', '=', binding.external_id),


### PR DESCRIPTION
The constraint did not look for inactive projects, which makes the import
fail later because it finds several projects for the same task.