### PR TITLE
Handle 404 errors when importing records

### DIFF
--- a/connector_jira/components/importer.py
+++ b/connector_jira/components/importer.py
@@ -235,6 +235,19 @@ class JiraImporter(Component):
                 else:
                     cr.commit()
 
+    def _handle_record_missing_on_jira(self):
+        """Hook called when we are importing a record missing on Jira
+
+        By default it deletes the matching record or binding if it exists on
+        Odoo and returns a result to show on the job, job will be done.
+        """
+        binding = self._get_binding()
+        if binding:
+            # emptying the external_id allows to unlink the binding
+            binding.external_id = False
+            binding.unlink()
+        return _('Record does no longer exist in Jira')
+
     def run(self, external_id, force=False, record=None, **kwargs):
         """ Run the synchronization
 
@@ -259,7 +272,7 @@ class JiraImporter(Component):
             try:
                 self.external_record = self._get_external_data()
             except IDMissingInBackend:
-                return _('Record does no longer exist in Jira')
+                return self._handle_record_missing_on_jira()
         binding = self._get_binding()
         if not binding:
             with self.do_in_new_work_context() as new_work:

--- a/connector_jira/models/account_analytic_line/common.py
+++ b/connector_jira/models/account_analytic_line/common.py
@@ -162,7 +162,8 @@ class WorklogAdapter(Component):
     _apply_on = ['jira.account.analytic.line']
 
     def read(self, issue_id, worklog_id):
-        return self.client.worklog(issue_id, worklog_id).raw
+        with self.handle_404():
+            return self.client.worklog(issue_id, worklog_id).raw
 
     def search(self, issue_id):
         """ Search worklogs of an issue """

--- a/connector_jira/models/account_analytic_line/importer.py
+++ b/connector_jira/models/account_analytic_line/importer.py
@@ -223,6 +223,19 @@ class AnalyticLineImporter(Component):
             external_id, force=force, record=record, **kwargs
         )
 
+    def _handle_record_missing_on_jira(self):
+        """Hook called when we are importing a record missing on Jira
+
+        For worklogs, we drop the analytic line if we discover it doesn't exist
+        on Jira, as the latter is the master.
+        """
+        binding = self._get_binding()
+        if binding:
+            record = binding.odoo_id
+            binding.unlink()
+            record.unlink()
+        return _('Record does no longer exist in Jira')
+
     def _get_external_data(self):
         """ Return the raw Jira data for ``self.external_id`` """
         issue_adapter = self.component(

--- a/connector_jira/models/jira_issue_type/common.py
+++ b/connector_jira/models/jira_issue_type/common.py
@@ -42,7 +42,8 @@ class IssueTypeAdapter(Component):
     _apply_on = ['jira.issue.type']
 
     def read(self, id_):
-        return self.client.issue_type(id_).raw
+        with self.handle_404():
+            return self.client.issue_type(id_).raw
 
     def search(self):
         issues = self.client.issue_types()

--- a/connector_jira/models/project_project/common.py
+++ b/connector_jira/models/project_project/common.py
@@ -290,13 +290,16 @@ class ProjectAdapter(Component):
     _apply_on = ['jira.project.project']
 
     def read(self, id_):
-        return self.get(id_).raw
+        with self.handle_404():
+            return self.get(id_).raw
 
     def get(self, id_):
-        return self.client.project(id_)
+        with self.handle_404():
+            return self.client.project(id_)
 
     def write(self, id_, values):
-        self.get(id_).update(values)
+        with self.handle_404():
+            self.get(id_).update(values)
 
     def create(self, key=None, name=None, template_name=None, values=None):
         project = self.client.create_project(

--- a/connector_jira/models/project_task/common.py
+++ b/connector_jira/models/project_task/common.py
@@ -161,10 +161,12 @@ class TaskAdapter(Component):
     _apply_on = ['jira.project.task']
 
     def read(self, id_, fields=None):
-        return self.client.issue(id_, fields=fields).raw
+        with self.handle_404():
+            return self.client.issue(id_, fields=fields).raw
 
     def get(self, id_):
-        return self.client.issue(id_)
+        with self.handle_404():
+            return self.client.issue(id_)
 
     def search(self, jql):
         # we need to have at least one field which is not 'id' or 'key'

--- a/connector_jira/models/res_users/common.py
+++ b/connector_jira/models/res_users/common.py
@@ -101,7 +101,8 @@ class UserAdapter(Component):
     _apply_on = ['jira.res.users']
 
     def read(self, id_):
-        return self.client.user(id_).raw
+        with self.handle_404():
+            return self.client.user(id_).raw
 
     def search(self, fragment=None):
         """ Search users

--- a/connector_jira_servicedesk/models/jira_organization/adapter.py
+++ b/connector_jira_servicedesk/models/jira_organization/adapter.py
@@ -40,7 +40,8 @@ class OrganizationAdapter(Component):
             self.client._options,
             self.client._session
         )
-        organization.find(id_)
+        with self.handle_404():
+            organization.find(id_)
         return organization.raw
 
     def search(self):


### PR DESCRIPTION
When a record does not exist on Jira:

* the job is done instead of failed
* a result on the job tells about the missing record
* the binding is deleted on Odoo
* for worklogs, the analytic line is deleted as well