### PR TITLE
Prevent changing task's project on binding

### DIFF
--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -103,6 +103,16 @@ class ProjectTaskMapper(Component):
     def backend_id(self, record):
         return {'backend_id': self.backend_record.id}
 
+    def finalize(self, map_record, values):
+        values = values.copy()
+        if values.get('odoo_id'):
+            # If a mapping binds the issue to an existing odoo
+            # task, we should not change the project.
+            # It's not only unexpected, but would fail as soon
+            # as we have invoiced timesheet lines on the task.
+            values.pop('project_id')
+        return values
+
 
 class ProjectTaskBatchImporter(Component):
     """ Import the Jira tasks


### PR DESCRIPTION
When the task Mapper binds a task to a task already existing in Odoo,
we must not change the project_id of the task. This is not possible as
long as we have invoiced timesheet lines, even if the id is the same
than the current one.