### PR TITLE
Do not change project_id on tasks updates

### DIFF
--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -3,7 +3,7 @@
 
 from odoo import _
 from odoo.addons.connector.exception import MappingError
-from odoo.addons.connector.components.mapper import mapping
+from odoo.addons.connector.components.mapper import mapping, only_create
 from odoo.addons.component.core import Component
 
 
@@ -74,6 +74,7 @@ class ProjectTaskMapper(Component):
         # and the Odoo field is HTML...
         return {'description': record['fields']['description']}
 
+    @only_create
     @mapping
     def project(self, record):
         binder = self.binder_for('jira.project.project')


### PR DESCRIPTION
When a task has invoiced timesheet lines, writing on 'project_id', even
if the id is the same, would fail because of a constraint preventing to
write project_id on timesheet lines.