### PR TITLE
Manage inactive project/task cases when importing timesheet/task

### DIFF
--- a/connector_jira/models/project_task/importer.py
+++ b/connector_jira/models/project_task/importer.py
@@ -77,7 +77,10 @@ class ProjectTaskMapper(Component):
     def project(self, record):
         binder = self.binder_for('jira.project.project')
         project = binder.unwrap_binding(self.options.project_binding)
-        return {'project_id': project.id}
+        values = {'project_id': project.id}
+        if not project.active:
+            values['active'] = False
+        return values
 
     @mapping
     def epic(self, record):


### PR DESCRIPTION
* When import timesheet:
  * use fallback project when project is inactive
  * don't use task if task is inactive
* Imported task on inactive project set task inactive too